### PR TITLE
Improve computer player behavior

### DIFF
--- a/src/computer-player.vala
+++ b/src/computer-player.vala
@@ -175,6 +175,10 @@ public class ComputerPlayer
         return b.n_tiles - a.n_tiles;
     }
 
+    /* Perhaps surprisingly, the *lower* the return value from this method,
+     * the "better" the position. So callers want to minimize the result here
+     * to find the best move.
+     */
     private int calculate_heuristic (Game g, Strategy strategy)
     {
         var tile_difference = g.n_dark_tiles - g.n_light_tiles;
@@ -193,7 +197,7 @@ public class ComputerPlayer
 
         /* Try to maximise a number of values */
         default:
-            return tile_difference + eval_heuristic (g);
+            return tile_difference - around (g) - eval_heuristic (g);
         }
     }
 


### PR DESCRIPTION
This change actually makes use of the around () and eval_heuristic () methods to improve the play of the AI player. At level 1, the behavior is the same as before.

For testing I ran matches against the old computer player which was playing LIGHT (both sides were at level 2). I ran a full game for each of the 244 potentially unique openings of 8 pieces (before 8 pieces are on the board, the computer just plays randomly).

When dark was played by the old code, its record was 100 - 141 - 3.
When dark was played by the new code, its record was 191 - 47- 6.

This is a significant improvement, and may turn out to be too difficult of an opponent, especially at level 3. We could try reducing the search depth to compensate... I'm not sure how to judge absolute difficulty of the AI.
